### PR TITLE
Mod images load optimization

### DIFF
--- a/Assets/Scripts/Application/Fucine/DataImport/CompendiumLoader.cs
+++ b/Assets/Scripts/Application/Fucine/DataImport/CompendiumLoader.cs
@@ -153,6 +153,9 @@ public class CompendiumLoader
         modManager.CatalogueMods();
         foreach (var mod in modManager.GetEnabledModsInLoadOrder())
         {
+            //should avoid doing that in CatalogueMods(), since it happens several times during load, and thus all images are loaded several times which is... sub-optimal
+            modManager.TryLoadImagesForEnabledMods(_log);
+
             var modContentLoader = new DataFileLoader(mod.ContentFolder);
             modContentLoader.LoadFilesFromAssignedFolder(_log);
             modContentLoaders.Add(modContentLoader);

--- a/Assets/Scripts/Application/Infrastructure/Modding/Mod.cs
+++ b/Assets/Scripts/Application/Infrastructure/Modding/Mod.cs
@@ -33,7 +33,6 @@ namespace SecretHistories.Constants.Modding
         string DescriptionLong { get; set; }
         List<Dependency> Dependencies { get; set; }
         Dictionary<string, List<Hashtable>> Contents { get; set; }
-        Dictionary<string, Sprite> Images { get; set; }
         bool Enabled { get; set; }
         string ModRootFolder { get; set; }
         string PublishedFileIdPath { get; }
@@ -72,8 +71,6 @@ namespace SecretHistories.Constants.Modding
         public List<Dependency> Dependencies { get; set; }
 
         public Dictionary<string, List<Hashtable>> Contents { get; set; }
-
-        public Dictionary<string, Sprite> Images { get; set; }
         
         public bool Enabled { get; set; }
 
@@ -110,7 +107,6 @@ namespace SecretHistories.Constants.Modding
 
             Dependencies =  new List<Dependency>();
             Contents = new Dictionary<string, List<Hashtable>>();
-            Images = new Dictionary<string, Sprite>();
             Enabled = false;
             IsValid = true;
         }
@@ -217,63 +213,6 @@ namespace SecretHistories.Constants.Modding
             }
 
             return errors;
-        }
-
-
-        public bool LoadImage(string imageFilePath)
-        {
-            //need to determine the subfolder tidily, to avoid absolute path problem for image key
-
-            Sprite spriteToLoad;
-
-            
-            //we don't want the absolute root in here, because later we'll match it against relative locations for core images
-            string relativePath = imageFilePath.Replace(ModRootFolder, string.Empty);
-
-            
-            string relativePathWithoutFileExtension = relativePath.Replace(Path.GetFileName(relativePath),
-                Path.GetFileNameWithoutExtension(relativePath));
-
-            string relativePathWithoutLeadingSlash = relativePathWithoutFileExtension.Remove(0, 1);
-
-            try
-            {
-                spriteToLoad = LoadSprite(imageFilePath);
-            }
-            catch
-            {
-                NoonUtility.Log(
-                    "Invalid image file '" + imageFilePath + "'",
-                    2);
-                return false;
-            }
-
-            Images.Add(relativePathWithoutLeadingSlash, spriteToLoad);
-
-            return true;
-        }
-
-        private Sprite LoadSprite(string imagePath)
-        {
-            Sprite sprite;
-
-            if (!File.Exists(imagePath))
-                return null;
-
-            var fileData = File.ReadAllBytes(imagePath);
-
-            // Try to load the image data into a sprite
-
-
-            var texture = new Texture2D(2, 2);
-            texture.LoadImage(fileData);
-            texture.filterMode = FilterMode.Trilinear;
-            texture.anisoLevel = 9;
-            texture.mipMapBias = (float)-0.5;
-            texture.Apply();
-            sprite = Sprite.Create(
-                texture, new Rect(0.0f, 0.0f, texture.width, texture.height), new Vector2(0.5f, 0.5f));
-            return sprite;
         }
 
         public bool HasValidLocFolder()

--- a/Assets/Scripts/Application/Infrastructure/Modding/ModManager.cs
+++ b/Assets/Scripts/Application/Infrastructure/Modding/ModManager.cs
@@ -416,6 +416,7 @@ namespace SecretHistories.Constants.Modding
 
         public Sprite GetSprite(string spriteResourceName)
         {
+            spriteResourceName = SlashInvariant(spriteResourceName);
             if (Images.ContainsKey(spriteResourceName))
                 return Images[spriteResourceName];
             else
@@ -490,9 +491,9 @@ namespace SecretHistories.Constants.Modding
                 return false;
             }
 
-
+            string relativePathUnified = relativePathWithoutLeadingSlash.Replace("\\", "/");
             //setting the value directly, without Add(), so earlier Images with the same name are overwritten (allowing mods to change images used in other mods)
-            Images[relativePathWithoutFileExtension] = spriteToLoad;
+            Images[relativePathUnified] = spriteToLoad;
 
             return true;
         }
@@ -518,6 +519,14 @@ namespace SecretHistories.Constants.Modding
             sprite = Sprite.Create(
                 texture, new Rect(0.0f, 0.0f, texture.width, texture.height), new Vector2(0.5f, 0.5f));
             return sprite;
+        }
+
+        private string SlashInvariant(string pathToAsset)
+        {
+            //to avoid any possible confusion between slashes, we replace all '/', if they are somehow present, into '\\'
+            //it's irrelevant what changed into what, we just need to make sure only one will be present when we're both storing and retrieving an asset
+            //(currently used only in LoadImage() to store Sprite, and in GetSprite())
+            return pathToAsset.Replace('/', '\\');
         }
 
         public void SwapModsInLoadOrderAndPersistToFile(int thisModIndex, int swapWithModIndex)

--- a/Assets/Scripts/Application/Infrastructure/Modding/ModManager.cs
+++ b/Assets/Scripts/Application/Infrastructure/Modding/ModManager.cs
@@ -416,9 +416,6 @@ namespace SecretHistories.Constants.Modding
 
         public Sprite GetSprite(string spriteResourceName)
         {
-            spriteResourceName = SlashInvariant(spriteResourceName);
-                
-            NoonUtility.LogWarning(spriteResourceName);
             if (Images.ContainsKey(spriteResourceName))
                 return Images[spriteResourceName];
             else
@@ -494,11 +491,8 @@ namespace SecretHistories.Constants.Modding
             }
 
 
-            //we'll do the same when retrieving any loaded image in  GetSprite()
-            string relativePathUnified = SlashInvariant(relativePathWithoutLeadingSlash);
             //setting the value directly, without Add(), so earlier Images with the same name are overwritten (allowing mods to change images used in other mods)
-            NoonUtility.LogWarning(relativePathUnified);
-            Images[relativePathUnified] = spriteToLoad;
+            Images[relativePathWithoutFileExtension] = spriteToLoad;
 
             return true;
         }
@@ -524,14 +518,6 @@ namespace SecretHistories.Constants.Modding
             sprite = Sprite.Create(
                 texture, new Rect(0.0f, 0.0f, texture.width, texture.height), new Vector2(0.5f, 0.5f));
             return sprite;
-        }
-
-        private string SlashInvariant(string pathToAsset)
-        {
-            //to avoid any possible confusion between slashes, we replace all '\', if they are somehow present, into '/'
-            //it should be irrelevant what changed into what, we just need to make sure only one will be present both when we're storing and retrieving an asset
-            //currently used only in LoadImage() to store Sprite, and in GetSprite()
-            return pathToAsset.Replace('\\', '/');
         }
 
         public void SwapModsInLoadOrderAndPersistToFile(int thisModIndex, int swapWithModIndex)

--- a/Assets/Scripts/Application/Infrastructure/Modding/ModManager.cs
+++ b/Assets/Scripts/Application/Infrastructure/Modding/ModManager.cs
@@ -36,6 +36,8 @@ namespace SecretHistories.Constants.Modding
 
         private readonly Dictionary<string, Mod> _cataloguedMods;
         private List<string> _enabledModsLoadOrder;
+        private List<Mod> _enabledMods;
+        private Dictionary<string, Sprite> Images;
 
         public void LoadModDLLs()
         {
@@ -81,6 +83,8 @@ namespace SecretHistories.Constants.Modding
         public ModManager()
         {
             _cataloguedMods = new Dictionary<string, Mod>();
+            _enabledMods = new List<Mod>();
+            Images = new Dictionary<string, Sprite>();
         }
 
         public IEnumerable<Mod> GetCataloguedMods()
@@ -89,21 +93,9 @@ namespace SecretHistories.Constants.Modding
             return cataloguedMods;
         }
 
-        public IEnumerable<Mod> GetEnabledModsInLoadOrder()
+        public List<Mod> GetEnabledModsInLoadOrder()
         {
-            var orderedIds = GetEnabledModsLoadOrderList();
-            var orderedMods=new List<Mod>();
-            foreach (var oi in orderedIds)
-            {
-                if (_cataloguedMods.ContainsKey(oi) && orderedMods.All(om => om.Id != oi)) // second clause is in case something broke and a duplicate snuck in
-                    orderedMods.Add(_cataloguedMods[oi]);
-                else
-                    NoonUtility.LogWarning(
-                        $"Problem getting enabled mod lists: {oi} was found in the enabled loading order list, but not in the catalogue");
-
-            }
-
-            return orderedMods;
+            return new List<Mod>(_enabledMods);
         }
 
         public IEnumerable<Mod> GetDisabledMods()
@@ -223,13 +215,15 @@ namespace SecretHistories.Constants.Modding
                 if (!_cataloguedMods.ContainsKey(modId))
                     _enabledModsLoadOrder.Remove(modId);
             }
-            
+
             // Set the enabled flag in all catalogued mods in the enabled list
+            _enabledMods.Clear();
             foreach (var modId in _enabledModsLoadOrder)
-            {
                 if (_cataloguedMods.ContainsKey(modId))
+                {
+                    _enabledMods.Add(_cataloguedMods[modId]);
                     _cataloguedMods[modId].Enabled = true;
-            }
+                }
         }
 
     private Dictionary<string, Mod> CatalogueModsInFolders(IEnumerable<string> inFolders,ModInstallType modInstallTypeForLocation)
@@ -323,7 +317,8 @@ namespace SecretHistories.Constants.Modding
             mod.LocFolder = candidateLocFolder;
         }
 
-        if (TryLoadAllImages(mod, modFolder))
+        var imagesFolderForMod = Path.Combine(modFolder, "images");
+        if (Directory.Exists(imagesFolderForMod))
             mod.CataloguingLog += " has a valid images directory; ";
         else
             mod.CataloguingLog += " has no valid images directory; ";
@@ -361,7 +356,13 @@ namespace SecretHistories.Constants.Modding
 
         private IEnumerable<String> GetEnabledModsLoadOrderFromFile()
         {
-            return File.Exists(ModEnabledListPath) ? File.ReadAllText(ModEnabledListPath).Split('\n') : new string[] { };
+            string[] allEnabled = File.Exists(ModEnabledListPath) ? File.ReadAllText(ModEnabledListPath).Split('\n') : new string[0];
+            //guaranteeing that list contains only unique mod ids
+            List<string> uniqueEnabled = new List<string>();
+            foreach (string id in allEnabled)
+                if (uniqueEnabled.Contains(id) == false)
+                    uniqueEnabled.Add(id);
+            return uniqueEnabled;
         }
 
         private void PersistEnabledModsLoadOrderToFile()
@@ -415,16 +416,13 @@ namespace SecretHistories.Constants.Modding
 
         public Sprite GetSprite(string spriteResourceName)
         {
-            
-            foreach (var mod in _cataloguedMods.Values)
-            {
-                if (mod.Enabled && mod.Images.ContainsKey(spriteResourceName))
-                {
-                    return mod.Images[spriteResourceName];
-                }
-            }
-
-            return null;
+            spriteResourceName = SlashInvariant(spriteResourceName);
+                
+            NoonUtility.LogWarning(spriteResourceName);
+            if (Images.ContainsKey(spriteResourceName))
+                return Images[spriteResourceName];
+            else
+                return null;
         }
 
 
@@ -443,27 +441,67 @@ namespace SecretHistories.Constants.Modding
 
 
 
-        private bool TryLoadAllImages(Mod mod, string modPath)
+        public void TryLoadImagesForEnabledMods(ContentImportLog log)
         {
-
-            var imagesFolderForMod = Path.Combine(modPath, "images");
-            // Search all subdirectories for more image files
-            
-            if (Directory.Exists(imagesFolderForMod))
+            foreach (Mod mod in _enabledMods)
             {
-                var imageFiles = GetFilesRecursive(imagesFolderForMod, ".png");
-                if (!imageFiles.Any())
-                    return false;
+                var imagesFolderForMod = Path.Combine(mod.ModRootFolder, "images");
+                // Search all subdirectories for more image files
 
-                foreach (var imageFile in imageFiles)
-                    mod.LoadImage(imageFile);
+                if (Directory.Exists(imagesFolderForMod))
+                {
+                    var imageFiles = GetFilesRecursive(imagesFolderForMod, ".png");
+                    if (!imageFiles.Any())
+                        return;
 
-                return true;
+                    foreach (var imageFile in imageFiles)
+                    {
+                        if (Images.ContainsKey(imageFile))
+                            log.LogWarning($"Duplicate image {imageFile} in {imagesFolderForMod}; overwriting previously loaded image.");
+
+                        LoadImage(mod.ModRootFolder, imageFile);
+                    }
+                }
             }
-            else
-                return false;
         }
 
+        private bool LoadImage(string rootFolder, string imageFilePath)
+        {
+            //need to determine the subfolder tidily, to avoid absolute path problem for image key
+
+            Sprite spriteToLoad;
+
+
+            //we don't want the absolute root in here, because later we'll match it against relative locations for core images
+            string relativePath = imageFilePath.Replace(rootFolder, string.Empty);
+
+
+            string relativePathWithoutFileExtension = relativePath.Replace(Path.GetFileName(relativePath),
+                Path.GetFileNameWithoutExtension(relativePath));
+
+            string relativePathWithoutLeadingSlash = relativePathWithoutFileExtension.Remove(0, 1);
+
+            try
+            {
+                spriteToLoad = LoadSprite(imageFilePath);
+            }
+            catch
+            {
+                NoonUtility.Log(
+                    "Invalid image file '" + imageFilePath + "'",
+                    2);
+                return false;
+            }
+
+
+            //we'll do the same when retrieving any loaded image in  GetSprite()
+            string relativePathUnified = SlashInvariant(relativePathWithoutLeadingSlash);
+            //setting the value directly, without Add(), so earlier Images with the same name are overwritten (allowing mods to change images used in other mods)
+            NoonUtility.LogWarning(relativePathUnified);
+            Images[relativePathUnified] = spriteToLoad;
+
+            return true;
+        }
 
         private Sprite LoadSprite(string imagePath)
         {
@@ -486,6 +524,14 @@ namespace SecretHistories.Constants.Modding
             sprite = Sprite.Create(
                 texture, new Rect(0.0f, 0.0f, texture.width, texture.height), new Vector2(0.5f, 0.5f));
             return sprite;
+        }
+
+        private string SlashInvariant(string pathToAsset)
+        {
+            //to avoid any possible confusion between slashes, we replace all '\', if they are somehow present, into '/'
+            //it should be irrelevant what changed into what, we just need to make sure only one will be present both when we're storing and retrieving an asset
+            //currently used only in LoadImage() to store Sprite, and in GetSprite()
+            return pathToAsset.Replace('\\', '/');
         }
 
         public void SwapModsInLoadOrderAndPersistToFile(int thisModIndex, int swapWithModIndex)

--- a/Assets/Scripts/Application/Tokens/Elements/Manifestations/CardManifestation.cs
+++ b/Assets/Scripts/Application/Tokens/Elements/Manifestations/CardManifestation.cs
@@ -98,7 +98,8 @@ namespace SecretHistories.Manifestations
             decayBackgroundImage = decayView.GetComponent<Image>();
             cachedDecayBackgroundColor = decayBackgroundImage.color;
 
-            frames = ResourcesManager.GetAnimFramesForElement(manifestable.EntityId);
+            string icon = Watchman.Get<Compendium>().GetEntityById<Element>(manifestable.EntityId).Icon;
+            frames = ResourcesManager.GetAnimFramesForElement(icon);
             _entityId = manifestable.EntityId;
             _quantity = manifestable.Quantity;
 


### PR DESCRIPTION
The game loads *all* the images from *all* the mods (even disabled ones). To make things worse, it does it *twice* for each Compendium population. These changes fix both of these issues.

In addition:
- Element animations now recognize subfolders.
- ModManager now keeps all mods' images (instead of each separate Mod having its separate Images property). Two reasons:
	- It's not possible to retrieve two different images with the same name [in two different mods] anyway [within the current framework] - so there's no sense in keeping both of them, if that happens.
	- The behaviour of two images "overlapping" (having  the same name) was not consistent. Now the one that gets loaded later "overrides" the one that's loaded earlier (thus, mods that are loaded later can "override" images from earlier mods - so behaviour is uniform with JSONs).

In additional addition:
ModManager.SlashInvariant() method ensures that wherever the game stores or tries to retrieve any modded Sprite asset, it 100% uses the same style of slash, regardless of the current system. The only possible thing to afraid of is the additional garbage generated by the string replacement, but my checks revealed no anomalies (which makes sense, since ResourceManager operates on the strings all the time anyway).