### PR TITLE
Slash inconsistencies in image loading

### DIFF
--- a/Assets/Scripts/Application/Infrastructure/ResourcesManager.cs
+++ b/Assets/Scripts/Application/Infrastructure/ResourcesManager.cs
@@ -38,9 +38,10 @@ public class ResourcesManager: MonoBehaviour
 
         int i = 0;
 
+        string animFolderPath = Path.Combine("verbs", "anim");
         while (true)
         {
-            var s= GetSprite("verbs\\anim", verbId + "_" + i, false);
+            var s= GetSprite(animFolderPath, verbId + "_" + i, false);
             if (s != null)
             {
                 frames.Add(s);
@@ -83,7 +84,8 @@ public class ResourcesManager: MonoBehaviour
 
         //This doesn't look for the placeholder image: this is intentional (we don't want a flickering pink question mark)
         //but might be a good way to spot missing animations
-        return GetSprite("elements\\anim", imageName + "_" + animFrame, false);
+        string animFolderPath = Path.Combine("elements", "anim");
+        return GetSprite(animFolderPath, imageName + "_" + animFrame, false);
     }
 
     public static List<Sprite> GetAnimFramesForElement(string imageName)
@@ -95,10 +97,10 @@ public class ResourcesManager: MonoBehaviour
         List<Sprite> frames = new List<Sprite>();
 
         int i = 0;
-
+        string animFolderPath = Path.Combine("elements", "anim");
         while (true)
         {
-            var s = GetSprite("elements\\anim", imageName + "_" + i, false);
+            var s = GetSprite(animFolderPath, imageName + "_" + i, false);
             if (s != null)
             {
                 frames.Add(s);
@@ -118,7 +120,7 @@ public class ResourcesManager: MonoBehaviour
 
     public static Sprite GetSpriteForCardBack(string backId) {
         //hardcoded to the books back at the moment
-        return GetSprite("cardbacks\\", "books");
+        return GetSprite("cardbacks", "books");
     }
 
     public static Sprite GetSpriteForAspect(string imageName)

--- a/Assets/Scripts/Application/UI/OptionsPanelTab.cs
+++ b/Assets/Scripts/Application/UI/OptionsPanelTab.cs
@@ -1,8 +1,10 @@
 ﻿using System.Globalization;
 using System.Threading;
+using System.IO;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+
 
 public class OptionsPanelTab : MonoBehaviour
 {
@@ -18,7 +20,8 @@ public class OptionsPanelTab : MonoBehaviour
     {
         TabId = tabId;
         _parentOptionsPanel = parentOptionsPanel; TabText.GetComponent<Babelfish>().UpdateLocLabel(tabId);
-        TabImage.sprite=ResourcesManager.GetSprite("ui/tabs", tabId);
+        string iconRelativePath = Path.Combine("tabs", tabId);
+        TabImage.sprite=ResourcesManager.GetSpriteForUI(iconRelativePath);
     }
 
     public void Activate()


### PR DESCRIPTION
Fixed slash inconsistencies that'll prevent verb/element animations (also custom option tabs) from loading on Mac/Linux.
